### PR TITLE
Fix vappasswd and vaprename to work on all supported RPi platforms

### DIFF
--- a/scripts/astroberry_vap
+++ b/scripts/astroberry_vap
@@ -9,18 +9,9 @@ if [[ $EUID -ne 0 ]]; then
    exit 1
 fi
 
-REVISION=$(grep Revision /proc/cpuinfo |awk -F: '{print $2}'|sed 's/\ //')
+source $(dirname $0)/vap-common.bash
 
-# take only 6 significant characters from right
-REVISION=${REVISION:(-6)}
-
-if [ "$REVISION" == "a02082" ] || [ "$REVISION" == "a32082" ] || [ "$REVISION" == "a52082" ]; then # Raspberry Pi 3B
-        VAPCONF="/etc/hostapd/hostapd_3b.conf"
-elif [ "$REVISION" == "a020d3" ]; then
-        VAPCONF="/etc/hostapd/hostapd_3bplus.conf" # Raspberry Pi 3B+
-else
-        VAPCONF="/etc/hostapd/hostapd.conf"
-fi
+get_hostapd_conf_path
 
 function vap_start {
 	if [ "$(grep vap0 /proc/net/dev)" == "" ]; then

--- a/scripts/vap-common.bash
+++ b/scripts/vap-common.bash
@@ -1,0 +1,20 @@
+#!/bin/bash
+#
+# astroberry virtual access point configuration functions
+# Author: Geordan Rosario, geordan AT google DOT com
+# License: GPL 3.0
+
+REVISION=$(grep Revision /proc/cpuinfo |awk -F: '{print $2}'|sed 's/\ //')
+
+# take only 6 significant characters from right
+REVISION=${REVISION:(-6)}
+
+get_hostapd_conf_path() {
+	if [ "$REVISION" == "a02082" ] || [ "$REVISION" == "a32082" ] || [ "$REVISION" == "a52082" ]; then # Raspberry Pi 3B
+		VAPCONF="/etc/hostapd/hostapd_3b.conf"
+	elif [ "$REVISION" == "a020d3" ]; then
+		VAPCONF="/etc/hostapd/hostapd_3bplus.conf" # Raspberry Pi 3B+
+	else
+		VAPCONF="/etc/hostapd/hostapd.conf"
+	fi
+}

--- a/scripts/vappasswd
+++ b/scripts/vappasswd
@@ -9,6 +9,10 @@ if [[ $EUID -ne 0 ]]; then
    exit 1
 fi
 
+source $(dirname $0)/vap-common.bash
+
+get_hostapd_conf_path
+
 echo "Enter your new Virtual Access Point password"
 read -sp "New password:" NEWPSK
 echo
@@ -25,13 +29,13 @@ if [ "$NEWPSK" != "$NEWPSK2" ]; then
    exit 1
 fi
 
-if [ -f /etc/hostapd/hostapd.conf ]; then
-    OLDPSK=$(grep wpa_passphrase /etc/hostapd/hostapd.conf|awk -F= '{print $2}')
+if [ -f ${VAPCONF} ]; then
+    OLDPSK=$(grep wpa_passphrase ${VAPCONF}|awk -F= '{print $2}')
     if [ -z "$OLDPSK" ]; then
        echo "Error changing Virtual Access Point password!"
        exit 1
     else
-       sed -i -e "s/wpa_passphrase=$OLDPSK/wpa_passphrase=$NEWPSK/g" /etc/hostapd/hostapd.conf
+       sed -i -e "s/wpa_passphrase=$OLDPSK/wpa_passphrase=$NEWPSK/g" ${VAPCONF}
        echo "Virtual Access Point password changed successfully. You need to reboot to activate changes."
        exit 0
     fi

--- a/scripts/vaprename
+++ b/scripts/vaprename
@@ -9,6 +9,10 @@ if [[ $EUID -ne 0 ]]; then
    exit 1
 fi
 
+source $(dirname $0)/vap-common.bash
+
+get_hostapd_conf_path
+
 echo "Enter your Virtual Access Point name"
 read -p "Name:" SSID
 
@@ -17,13 +21,13 @@ if [ -z "$SSID" ]; then
    exit 1
 fi
 
-if [ -f /etc/hostapd/hostapd.conf ] ; then
-    OLDSSID=$(grep "^ssid=" /etc/hostapd/hostapd.conf|awk -F= '{print $2}')
+if [ -f ${VAPCONF} ] ; then
+    OLDSSID=$(grep "^ssid=" ${VAPCONF}|awk -F= '{print $2}')
     if [ -z "$OLDSSID" ]; then
        echo "Error renaming Virtual Access Point!"
        exit 1
     else
-       sed -i -e "s/ssid=$OLDSSID/ssid=$SSID/g" /etc/hostapd/hostapd.conf
+       sed -i -e "s/ssid=$OLDSSID/ssid=$SSID/g" ${VAPCONF}
        echo "Virtual Access Point renamed to $SSID. You need to reboot to activate changes."
        exit 0
     fi


### PR DESCRIPTION
Fixes bug where `vappasswd` and `vaprename` don't update the VAP configuration on Raspberry Pi 3B+ (and, presumably 3B) because they use different configuration files.